### PR TITLE
Add a --wait-for-deploy option for OpsWorks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ provided by the `AWS_DEFAULT_REGION` environment variable.
   revision number, to deploy.
 - `--migrate` (optional) Enable migrations.
 - `--comment STRING` (optional) Comment for the deployment.
+- `--wait-for-deploy` (optional) Waits for deployments to complete before
+  exiting, and reports the result.
 
 #### Permissions
 

--- a/lib/deployer/opsworks.js
+++ b/lib/deployer/opsworks.js
@@ -103,6 +103,35 @@ OpsWorksDeployer.prototype.done = function(err) {
   this.emit('done', err);
 };
 
+OpsWorksDeployer.prototype.waitForDeploy = function(id) {
+  var api = this.getApi(),
+      deployer = this;
+
+  api.describeDeployments({
+    'DeploymentIds': [id]
+  }, function(err, data) {
+    if (err) {
+      deployer.emit('error', err);
+      return;
+    }
+
+    var deploymentStatus = data.Deployments[0].Status;
+
+    debugger;
+    switch (deploymentStatus) {
+      case 'successful':
+        deployer.emit('done');
+        break;
+      case 'running':
+        deployer.waitForDeploy(id);
+        break;
+      case 'failed':
+        deployer.emit('error', new Error('Deploy failed!'));
+        break;
+    }
+  });
+};
+
 OpsWorksDeployer.prototype.deploy = function() {
   var api = this.getApi(),
       deployer = this,
@@ -121,13 +150,23 @@ OpsWorksDeployer.prototype.deploy = function() {
 
   this.getApp(function(err, app) {
     if (err) {
-      return callback(err);
+      deployer.emit('error', err);
+      return;
     }
 
     args['CustomJson'] = deployer.getJSON(app);
 
-    api.createDeployment(args, function() {
-      deployer.done();
+    api.createDeployment(args, function(err, data) {
+      if (err) {
+        deployer.emit('error', err);
+        return;
+      }
+
+      if (options.waitForDeploy) {
+        deployer.waitForDeploy(data.DeploymentId);
+      } else {
+        deployer.done();
+      }
     });
   });
 };

--- a/lib/dropper.js
+++ b/lib/dropper.js
@@ -4,6 +4,9 @@ function deploy(deployerName, options, callback) {
   var deployer = Deployer.get(deployerName, options);
 
   deployer.on('done', callback);
+  deployer.on('error', function(err) {
+    throw err;
+  });
 
   deployer.deploy();
 }

--- a/test/test_dropper.js
+++ b/test/test_dropper.js
@@ -25,4 +25,18 @@ describe('deploy', function() {
 
     deploy('fake', options, callback);
   });
+
+  it('should raise errors', function() {
+    function FakeDeployer() {}
+    FakeDeployer.prototype.__proto__ = EventEmitter.prototype;
+    FakeDeployer.prototype.deploy = function() {
+      this.emit('error', new Error('oh no!'));
+    };
+
+    Deployer.register('fake', FakeDeployer);
+
+    (function() {
+      deploy('fake', {}, function() {});
+    }).should.throw(/oh no/);
+  });
 });


### PR DESCRIPTION
This adds a `--wait-for-deploy` option for OpsWorks and improves error handling just a little bit.

Closes #5.
